### PR TITLE
Add alternative COVID mode

### DIFF
--- a/doc/sdate.1
+++ b/doc/sdate.1
@@ -21,6 +21,8 @@ sdate \- never ending September date
 .B sdate 
 .B [\-e|\-\-epoch
 .IB yyyy-mm]
+.B [\-c|\-\-covid
+.IB vv]
 .B [\-l|\-\-lib
 .IB library]
 .BI [\-\-]
@@ -39,6 +41,10 @@ mechanism of the dynamic loader. (See
 .TP
 \fB\-e\fR \fIyyyy-mm\fR, \fB\-\-epoch\fR \fIyyyy-mm\fR
 Specify an alternative epoch, default is 1993-09.
+.TP
+\fB\-c\fR \fIvv\fR, \fB\-\-covid\fR \fIvv\fR
+Enable COVID mode, for the specified variant. Sets epoch to
+an appropriate value for the variant.
 .TP
 \fB\-l\fR \fIlibrary\fR, \fB\-\-lib\fR \fIlibrary\fR
 Specify an alternative wrapper library.

--- a/scripts/sdate.in
+++ b/scripts/sdate.in
@@ -3,8 +3,8 @@
 usage () {
 cat - >&2 <<EOF
 sdate, never ending September date
-   usage: sdate [-e|--epoch yyyy-mm] [-l|--lib sdatelib] [-h|--help] [-v|--version]
-                [--] [command]
+   usage: sdate [-e|--epoch yyyy-mm] [-c|--covid vv] [-l|--lib sdatelib]
+                [-h|--help] [-v|--version] [--] [command]
 EOF
   exit 1
 }
@@ -21,10 +21,10 @@ libfound=no
 GETOPTEST=`getopt --version`
 case $GETOPTEST in
 getopt*) # GNU getopt
-    TEMP=`getopt -l lib: -l epoch: -l version -l help -- +l:f:e:s:ub:vh "$@"`
+    TEMP=`getopt -l lib: -l epoch: -l version -l help -- +l:f:e:c:s:ub:vh "$@"`
     ;;
 *) # POSIX getopt ?
-    TEMP=`getopt l:f:e:s:ub:vh "$@"`
+    TEMP=`getopt l:f:e:c:s:ub:vh "$@"`
     ;;
 esac
 
@@ -45,6 +45,19 @@ while test "X$1" != "X--"; do
        shift
        SDATE_EPOCH="$1"
        export SDATE_EPOCH
+       ;;
+    -c|--covid)
+       shift
+       case "$1" in
+	 19)
+	    SDATE_EPOCH="2020-03"
+	    export SDATE_EPOCH
+	    ;;
+	 *)
+	    echo "Unknown COVID variant - supported variants are: 19"
+	    exit 1
+	    ;;
+       esac
        ;;
     -v|--version)
        echo "sdate version @VERSION@"


### PR DESCRIPTION
Implement a COVID mode, enabled via new -c/--covid option with a mandatory
variant specfication. This mode sets epoch to an appropriate value for the
specific COVID variant. Also add initial support for variant 19, in order
to enable displaying the never ending March date.

Signed-off-by: Leif Lindholm <leif@eciton.net>