### PR TITLE
Add support to ppc64le

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -3,6 +3,9 @@
 language: C
 dist: bionic
 sudo: required
+arch:
+  - amd64
+  - ppc64le
 
 script:
   - autoreconf --install


### PR DESCRIPTION
This PR adds CI support to linux power architecture. Ubuntu distribution on this arch also has sdate project. Continuously building it on ppc64le along with intel ensure that any build/test issues are identified early in the stage and we are up-to-date.