### PR TITLE
Fix some issues reported by lintian

### DIFF
--- a/debian/changelog
+++ b/debian/changelog
@@ -1,3 +1,9 @@
+sdate (0.8) UNRELEASED; urgency=medium
+
+  * Trim trailing whitespace.
+
+ -- Debian Janitor <janitor@jelmer.uk>  Tue, 21 Sep 2021 04:57:42 -0000
+
 sdate (0.7) unstable; urgency=medium
 
   * Support COVID 19 date.
@@ -91,4 +97,3 @@ sdate (0.1) unstable; urgency=low
   * Sources copied from fakeroot 1.1.2.
 
  -- Christoph Berg <cb@df7cb.de>  Fri, 15 Oct 2004 18:05:54 +0200
-

--- a/debian/changelog
+++ b/debian/changelog
@@ -2,6 +2,7 @@ sdate (0.8) UNRELEASED; urgency=medium
 
   * Trim trailing whitespace.
   * Bump debhelper from old 12 to 13.
+  * Update standards version to 4.5.1, no changes needed.
 
  -- Debian Janitor <janitor@jelmer.uk>  Tue, 21 Sep 2021 04:57:42 -0000
 

--- a/debian/changelog
+++ b/debian/changelog
@@ -1,6 +1,7 @@
 sdate (0.8) UNRELEASED; urgency=medium
 
   * Trim trailing whitespace.
+  * Bump debhelper from old 12 to 13.
 
  -- Debian Janitor <janitor@jelmer.uk>  Tue, 21 Sep 2021 04:57:42 -0000
 

--- a/debian/control
+++ b/debian/control
@@ -7,7 +7,7 @@ Build-Depends:
  libc6-dev-s390x [s390],
  libc6-dev-sparc64 [sparc],
 Maintainer: Christoph Berg <myon@debian.org>
-Standards-Version: 4.5.0
+Standards-Version: 4.5.1
 Vcs-Git: https://github.com/df7cb/sdate.git
 Vcs-Browser: https://github.com/df7cb/sdate
 Homepage: https://www.df7cb.de/projects/sdate/

--- a/debian/control
+++ b/debian/control
@@ -3,7 +3,7 @@ Section: utils
 Priority: optional
 Build-Depends:
  debhelper (>= 12.8),
- debhelper-compat (= 12),
+ debhelper-compat (= 13),
  libc6-dev-s390x [s390],
  libc6-dev-sparc64 [sparc],
 Maintainer: Christoph Berg <myon@debian.org>


### PR DESCRIPTION
Fix some issues reported by lintian

* Trim trailing whitespace. ([trailing-whitespace](https://lintian.debian.org/tags/trailing-whitespace))

* Bump debhelper from old 12 to 13. ([package-uses-old-debhelper-compat-version](https://lintian.debian.org/tags/package-uses-old-debhelper-compat-version))

* Update standards version to 4.5.1, no changes needed. ([out-of-date-standards-version](https://lintian.debian.org/tags/out-of-date-standards-version))


This merge proposal was created automatically by the [Janitor bot](https://janitor.debian.net/lintian-fixes).
For more information, including instructions on how to disable
these merge proposals, see https://janitor.debian.net/lintian-fixes.

You can follow up to this merge proposal as you normally would.

The bot will automatically update the merge proposal to resolve merge conflicts
or close the merge proposal when all changes are applied through other means
(e.g. cherry-picks). Updates may take several hours to propagate.

Build and test logs for this branch can be found at
https://janitor.debian.net/lintian-fixes/pkg/sdate/34a783ed-9211-4efc-a0a2-50bc096e0ed5.
