### PR TITLE
sdate.1: Escape tilde character

### DIFF
--- a/doc/sdate.1
+++ b/doc/sdate.1
@@ -73,7 +73,7 @@ needs to be linked to the same version of the C library as
 itself.
 .SH SEE ALSO
 .TP
-http://www.catb.org/~esr/jargon/html/S/September-that-never-ended.html
+http://www.catb.org/\(tiesr/jargon/html/S/September-that-never-ended.html
 .TP
 https://www.df7cb.de/projects/sdate/
 .SH COPYING


### PR DESCRIPTION
The tilde (~) character in groff input produces a "modifier tilde" in the output. Use the \(ti escape sequence for a normal tilde, see groff_char(7).